### PR TITLE
spread: extract service account from credentials JSON

### DIFF
--- a/spread/google.go
+++ b/spread/google.go
@@ -852,13 +852,17 @@ func (p *googleProvider) checkKey() error {
 				creds, err = google.CredentialsFromJSON(ctx, raw, googleScope)
 			}
 
-			// identify service account if possible
-			p.serviceAccount, err = serviceAccountFromKey(raw)
 		} else {
 			// none provided, let the google library find whatever
 			// is appropriate
 			creds, err = google.FindDefaultCredentials(ctx, googleScope)
 		}
+
+		if err == nil {
+			// identify service account if possible
+			p.serviceAccount, err = serviceAccountFromKey(creds.JSON)
+		}
+
 		if err == nil {
 			p.client = oauth2.NewClient(ctx, creds.TokenSource)
 		}


### PR DESCRIPTION
Extract the service account information from credentials. This way it works with both explicit credentials passed through environment and default credentials read from $HOME/.config/gcloud/application_default_credentials.json.